### PR TITLE
Arreglos goatrun

### DIFF
--- a/src/js/scenes/GoatRun/BaseGoatRun.js
+++ b/src/js/scenes/GoatRun/BaseGoatRun.js
@@ -98,14 +98,14 @@ export default class BaseGoatRun extends Phaser.Scene {
 
         this.createBackground();
 
-        this.player = new Player_Goatrun(this, 320, 400, 'amaia_goatrun');
+        this.player = new Player_Goatrun(this, 320, 420, 'amaia_goatrun');
         this.physics.world.gravity.y = 400;
 
         this.heart1 = this.add.sprite(680, 30, 'hearts');
         this.heart2 = this.add.sprite(710, 30, 'hearts');
         this.heart3 = this.add.sprite(740, 30, 'hearts');
         
-        this.goat = this.physics.add.sprite(70, 280, 'goat');
+        this.goat = this.physics.add.sprite(70, 370, 'goat');
         this.goat.setSize(90, 180);
 
         this.createEnemies();
@@ -249,7 +249,7 @@ export default class BaseGoatRun extends Phaser.Scene {
 
         this.createInitialScreen();
 
-        this.scoreText = this.add.text(16, 16, 'Distance: 0/15000', { fontSize: '32px', fill: '#000', fontFamily: 'font'});
+        this.scoreText = this.add.text(16, 16, 'Distance: 0/8000', { fontSize: '32px', fill: '#000', fontFamily: 'font'});
         this.hechizoText = this.add.text(16, 46, 'Hechizo de gravedad - Activado', { fontSize: '32px', fill: '#000', fontFamily: 'font'});
         this.hechizoText.setVisible(false);
 
@@ -276,15 +276,10 @@ export default class BaseGoatRun extends Phaser.Scene {
     /*
         - Nivel 1, parecido al de dinosaurio de google, aparecen rapido y con frecuencia pero sin dificultad alguna. 
         Tambien aparece de vez en cuando un hechizo que te libera un poco de la gravedad durante 10 segundoss
-        DONE
-
 
         - Nivel 2, aparecen más rápidos y hay murcielagos que quitan dos vidas
-        DONE
-
 
         - Nivel 3, aparecen más frecuentes y algunas rocas tienen fuego, que te matan directamente
-        DONE
     */
 
     createEnemies(){
@@ -354,11 +349,12 @@ export default class BaseGoatRun extends Phaser.Scene {
                 this.firstStart = false;
             }
             if(!this.amaiaIsDeath){
-                this.background.tilePositionX += 0.15;
+                this.background.tilePositionX += 0.35;
                 this.distance += 1;
-                this.scoreText.setText('Distance: ' + (this.distance || '') + '/15000');
+                this.scoreText.setText('Distance: ' + (this.distance || '') + '/8000');
                 this.movimientoEnemies();
-                
+                console.log("pos amaia: " + this.player.body.position.y);
+                console.log("pos cabra: " + this.goat.body.position.y);
                     if(this.cursors.up.isDown){
                         if(!this.jump){ // Si no está saltando
                             this.player.jumps();
@@ -384,11 +380,13 @@ export default class BaseGoatRun extends Phaser.Scene {
                     else if (!this.changeCollider){
                         this.player.colliderNormal();
                     }
-            
+                    
+                    /*
                     if(this.cursors.left.isDown){ // Prueba para comprobar animación de muerte
                         this.deathScene();
                         this.amaiaIsDeath = true;
                     }
+                    */
 
                     if(this.hechizado == true){
                         this.hechizoText.setVisible(true);

--- a/src/js/scenes/GoatRun/goatrun_nivel1.js
+++ b/src/js/scenes/GoatRun/goatrun_nivel1.js
@@ -63,7 +63,7 @@ export default class GoatRun_Nivel1 extends BaseGoatRun {
         var numAleatorio = Math.random();
         if (numAleatorio < 0.5) {
           // Generamos una piedra
-          var objeto = new Rock(self, 950, 350, "rock", self.player, 1);
+          var objeto = new Rock(self, 950, 360, "rock", self.player, 1);
           self.rocks.add(objeto);
         } else {
           // Generamos un murcielago
@@ -89,7 +89,7 @@ export default class GoatRun_Nivel1 extends BaseGoatRun {
   }
 
   checkLevel() {
-    if (this.distance > 15000) {
+    if (this.distance > 8000) {
       this.changeScene();
       this.isInvulnerable = false;
       setTimeout(() => {

--- a/src/js/scenes/GoatRun/goatrun_nivel2.js
+++ b/src/js/scenes/GoatRun/goatrun_nivel2.js
@@ -71,7 +71,7 @@ export default class GoatRun_Nivel2 extends BaseGoatRun {
         var numAleatorio = Math.random();
         if (numAleatorio < 0.5) {
           // Generamos una piedra
-          var objeto = new Rock(self, 950, 350, "rock2", self.player, 2);
+          var objeto = new Rock(self, 950, 355, "rock2", self.player, 2);
           self.rocks.add(objeto);
         } else {
           // Generamos un murcielago
@@ -105,7 +105,7 @@ export default class GoatRun_Nivel2 extends BaseGoatRun {
   }
 
   checkLevel() {
-    if (this.distance > 15000) {
+    if (this.distance > 8000) {
       this.changeScene();
       this.isInvulnerable = false;
       setTimeout(() => {

--- a/src/js/scenes/GoatRun/goatrun_nivel3.js
+++ b/src/js/scenes/GoatRun/goatrun_nivel3.js
@@ -43,7 +43,7 @@ export default class GoatRun_Nivel3 extends BaseGoatRun {
       if (!this.amaiaIsDeath) {
         this.background.tilePositionX += 0.15;
         this.distance += 1;
-        this.scoreText.setText("Distance: " + (this.distance || "") + "/15000");
+        this.scoreText.setText("Distance: " + (this.distance || "") + "/8000");
         this.movimientoEnemies();
 
         if (this.cursors.up.isDown) {
@@ -75,12 +75,13 @@ export default class GoatRun_Nivel3 extends BaseGoatRun {
         } else if (!this.changeCollider) {
           this.player.colliderNormal();
         }
-
+        /*
         if (this.cursors.left.isDown) {
           // Prueba para comprobar animación de muerte
           this.deathScene();
           this.amaiaIsDeath = true;
         }
+        */
 
         if (this.hechizado == true) {
           this.hechizoText.setVisible(true);
@@ -191,19 +192,12 @@ export default class GoatRun_Nivel3 extends BaseGoatRun {
         if (numAleatorio < 0.5) {
           // Generamos una piedra
           var nA = Math.random();
-          if (nA > 0.5) {
+          if (nA > 0.4) {
             var objeto = new Rock(self, 950, 350, "rock3", self.player, 3);
             self.rocks.add(objeto);
           } else {
             // 1 de cada 2 aproximadamente son rocas que te matan (llenas de fuego)
-            var objeto = new FireRock(
-              self,
-              950,
-              350,
-              "fire_column_1",
-              self.player,
-              3
-            );
+            var objeto = new FireRock(self, 950, 350, "fire_column_1", self.player, 3);
             self.rocks.add(objeto);
           }
         } else {
@@ -238,7 +232,7 @@ export default class GoatRun_Nivel3 extends BaseGoatRun {
   }
 
   checkLevel() {
-    if (this.distance > 15000) {
+    if (this.distance > 8000) {
       this.changeScene();
       this.isInvulnerable = false;
       setTimeout(() => {


### PR DESCRIPTION
Reducida la distancia necesaria para completar cada nivel
Aparición de las piedras directamente desde el suelo para evitar que parezcan generadas
Aceleración del fondo de la cueva para dar sensación de movilidad
Eliminación de que si pulsas (<-) muera el personaje. Es decir, ya no pasa
Reducida la dificultad del último nivel (menos probabilidad de aparición de columna de fuego)
Al principio del nivel Amaia y la cabra no aparecen desde el cielo y aparecen directamente en el suelo. 
